### PR TITLE
(SBL-272) Fix bug in learn edit page

### DIFF
--- a/front/src/pages/Teacher/LessonEdit/LessonEdit.jsx
+++ b/front/src/pages/Teacher/LessonEdit/LessonEdit.jsx
@@ -1,6 +1,6 @@
 import { Button, Col, Input, message, Row, Typography } from 'antd';
 import DragDrop from 'editorjs-drag-drop';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useMutation, useQuery } from 'react-query';
 import { useHistory, useParams } from 'react-router-dom';
@@ -190,6 +190,11 @@ const LessonEdit = () => {
     }
   };
 
+  const status = useMemo(
+    () => lessonData?.lesson?.status?.toLocaleLowerCase() || 'none',
+    [lessonData],
+  );
+
   return (
     <>
       <Header>
@@ -215,9 +220,7 @@ const LessonEdit = () => {
               <S.BadgeWrapper>
                 <S.CardBadge>
                   <S.StatusText>
-                    {t(
-                      `lesson_dashboard.status.${lessonData?.lesson.status.toLocaleLowerCase()}`,
-                    )}
+                    {t(`lesson_dashboard.status.${status}`)}
                   </S.StatusText>
                 </S.CardBadge>
               </S.BadgeWrapper>

--- a/front/src/resources/lang/en/teacher.js
+++ b/front/src/resources/lang/en/teacher.js
@@ -20,6 +20,7 @@ export default {
       archived: 'Archived',
       public: 'Public',
       private: 'Private',
+      none: 'None',
     },
     status_select: {
       all: 'All statuses',

--- a/front/src/resources/lang/ru/teacher.js
+++ b/front/src/resources/lang/ru/teacher.js
@@ -20,6 +20,7 @@ export default {
       archived: 'Архивирован',
       public: 'Публичный',
       private: 'Приватный',
+      none: 'Отсуствует',
     },
     status_select: {
       all: 'Все статусы',


### PR DESCRIPTION
Fix problem: _on learn edit page if create new lesson (/teacher/lessons/new), status button (Draft, Public, Private) 
have status 'lesson_dashboard.status.undefined'_