### PR TITLE
(SBL-288) Fix: learn progress

### DIFF
--- a/api/src/models/Lesson.js
+++ b/api/src/models/Lesson.js
@@ -381,6 +381,10 @@ class Lesson extends BaseModel {
           (select count(*) from lesson_block_structure join blocks on blocks.block_id = lesson_block_structure.block_id
           where blocks.type in ('next', 'quiz') and lesson_block_structure.lesson_id = lessons.id) interactive_total
         `),
+        this.knex().raw(`
+          (select cast(case when count(*) > 0 then true else false end as bool) from results
+          where lesson_id = lessons.id and action = 'start' and user_id = ${userId}) is_started
+        `),
       )
       .from(
         this.knex().raw(`

--- a/api/src/models/LessonBlockStructure.js
+++ b/api/src/models/LessonBlockStructure.js
@@ -243,8 +243,27 @@ class LessonBlockStructure extends BaseModel {
     await this.query(trx).insert(blockStructure);
   }
 
-  static countBlocks({ lessonId }) {
-    return this.query().first().count().where({ lessonId });
+  static async countBlocks({ lessonId }) {
+    const { count: countInteractive } = await this.query()
+      .first()
+      .count()
+      .join('blocks', 'blocks.blockId', '=', 'lesson_block_structure.blockId')
+      .where({ lessonId })
+      .whereIn('blocks.type', config.interactiveBlocks);
+
+    if (!+countInteractive) {
+      const { count: countAll } = await this.query()
+        .first()
+        .count()
+        .where({ lessonId });
+
+      if (!+countAll) {
+        return { count: 0 };
+      }
+      return { count: 1 };
+    }
+
+    return { count: +countInteractive };
   }
 }
 

--- a/api/src/services/lesson/handlers/getLearn/handler.js
+++ b/api/src/services/lesson/handlers/getLearn/handler.js
@@ -28,14 +28,15 @@ export async function getLearnHandler({
    * get last record from the results table
    */
   const lastResult = await Result.getLastResult({ userId, lessonId });
+
+  const { count: total } = await LessonBlockStructure.countBlocks({
+    lessonId,
+  });
   /**
    * if the lesson was not started yet
    */
   if (!lastResult) {
     lesson.blocks = [];
-    const { count: total } = await LessonBlockStructure.countBlocks({
-      lessonId,
-    });
     return { total, lesson, isFinal: false };
   }
   /**
@@ -53,7 +54,7 @@ export async function getLearnHandler({
     lesson.blocks = mapResultToBlock({ blocks, dictionary });
 
     return {
-      total: blocks.length,
+      total,
       lesson,
       isFinished: true,
     };
@@ -61,7 +62,7 @@ export async function getLearnHandler({
   /**
    * else
    */
-  const { total, chunk, isFinal } = await LessonBlockStructure.getChunk({
+  const { chunk, isFinal } = await LessonBlockStructure.getChunk({
     lessonId,
     previousBlock: lastResult.blockId,
     fromStart: true,

--- a/api/src/services/lesson/handlers/learnLesson/handler.js
+++ b/api/src/services/lesson/handlers/learnLesson/handler.js
@@ -134,20 +134,21 @@ export async function learnLessonHandler({
     revision,
     data,
   });
+
+  const { count: total } = await LessonBlockStructure.countBlocks({
+    lessonId,
+  });
   /**
    * get all blocks on finish
    */
   if (action === 'finish') {
     const blocks = [];
-    const { count } = await LessonBlockStructure.countBlocks({
-      lessonId,
-    });
-    return { total: +count, blocks, isFinished: true };
+    return { total, blocks, isFinished: true };
   }
   /**
    * else get the next chunk of blocks
    */
-  const { total, chunk, isFinal } = await LessonBlockStructure.getChunk({
+  const { chunk, isFinal } = await LessonBlockStructure.getChunk({
     lessonId,
     previousBlock: blockId,
   });

--- a/api/src/services/lesson/handlers/ongoingLessons/options.js
+++ b/api/src/services/lesson/handlers/ongoingLessons/options.js
@@ -27,6 +27,7 @@ export const ongoingLessonsOptions = {
                 },
                 interactiveTotal: { type: 'number' },
                 interactivePassed: { type: 'number' },
+                isStarted: { type: 'boolean' },
               },
             },
           },

--- a/api/test/integration/learnFlow.spec.js
+++ b/api/test/integration/learnFlow.spec.js
@@ -274,7 +274,9 @@ describe('Learning flow', () => {
       expect(statusCode).toBe(200);
 
       expect(responseBody).toHaveProperty('total');
-      expect(responseBody.total).toBe(french._blocks._current.length);
+      expect(responseBody.total).toBe(
+        french._blocks._indexesOfInteractive.length,
+      );
 
       expect(responseBody).toHaveProperty('lesson');
       expect(responseBody.lesson).toHaveProperty('blocks');
@@ -338,7 +340,9 @@ describe('Learning flow', () => {
       expect(statusCode).toBe(200);
 
       expect(responseBody).toHaveProperty('total');
-      expect(responseBody.total).toBe(french._blocks._current.length);
+      expect(responseBody.total).toBe(
+        french._blocks._indexesOfInteractive.length,
+      );
 
       expect(responseBody).toHaveProperty('lesson');
       expect(responseBody.lesson).toHaveProperty('blocks');
@@ -458,7 +462,9 @@ describe('Learning flow', () => {
       expect(statusCode).toBe(200);
 
       expect(responseBody).toHaveProperty('total');
-      expect(responseBody.total).toBe(french._blocks._current.length);
+      expect(responseBody.total).toBe(
+        french._blocks._indexesOfInteractive.length,
+      );
 
       expect(responseBody).toHaveProperty('lesson');
       expect(responseBody.lesson).toHaveProperty('blocks');

--- a/front/src/components/lessonBlocks/OngoingFull/OngoingFull.desktop.jsx
+++ b/front/src/components/lessonBlocks/OngoingFull/OngoingFull.desktop.jsx
@@ -15,7 +15,7 @@ const OngoingFullDesktop = ({ lesson }) => {
   const { fullName, firstNameLetter, handleContinueLesson } = useLesson(lesson);
 
   const countPercentage = useMemo(() => {
-    if (lesson.isFinished) {
+    if ((!lesson.interactiveTotal && lesson.isStarted) || lesson.isFinished) {
       return 100;
     }
     return Math.round((interactivePassed / interactiveTotal) * 100);
@@ -31,7 +31,10 @@ const OngoingFullDesktop = ({ lesson }) => {
               <S.AuthorAvatar>{firstNameLetter}</S.AuthorAvatar>
               <S.AuthorName>{fullName}</S.AuthorName>
             </S.AuthorContainer>
-            <S.ProgressBar percent={countPercentage} />
+            <S.ProgressBar
+              percent={countPercentage}
+              status={lesson.isFinished ? 'success' : 'normal'}
+            />
           </div>
         </S.LeftContent>
         <S.RightContent>

--- a/front/src/components/lessonBlocks/OngoingFull/OngoingFull.mobile.jsx
+++ b/front/src/components/lessonBlocks/OngoingFull/OngoingFull.mobile.jsx
@@ -15,7 +15,7 @@ const OngoingFullMobile = ({ lesson }) => {
   const { fullName, firstNameLetter, handleContinueLesson } = useLesson(lesson);
 
   const countPercentage = useMemo(() => {
-    if (lesson.isFinished) {
+    if ((!lesson.interactiveTotal && lesson.isStarted) || lesson.isFinished) {
       return 100;
     }
     return Math.round((interactivePassed / interactiveTotal) * 100);
@@ -25,7 +25,10 @@ const OngoingFullMobile = ({ lesson }) => {
     <S.Main size="large" wrap={false}>
       <div>
         <S.Image src={lessonImage} alt="Lesson" />
-        <S.ProgressBar percent={countPercentage()} />
+        <S.ProgressBar
+          percent={countPercentage}
+          status={lesson.isFinished ? 'success' : 'normal'}
+        />
       </div>
       <Row>
         <S.Title

--- a/front/src/components/lessonBlocks/OngoingShort/OngoingShort.desktop.jsx
+++ b/front/src/components/lessonBlocks/OngoingShort/OngoingShort.desktop.jsx
@@ -21,15 +21,18 @@ const OngoingShortDesktop = ({ lesson }) => {
     history.push(LEARN_PAGE.replace(':id', id));
   };
 
-  const countPercentage = useMemo(() =>
-    Math.round((interactivePassed / interactiveTotal) * 100), 
-  [interactivePassed, interactiveTotal]);
+  const countPercentage = useMemo(() => {
+    if (!lesson.interactiveTotal && lesson.isStarted) {
+      return 100;
+    }
+    return Math.round((interactivePassed / interactiveTotal) * 100);
+  }, [lesson, interactivePassed, interactiveTotal]);
 
   return (
     <S.MainSpace>
       <S.LeftColumn span={8}>
         <img height={100} src={lessonImg} alt="Lesson" />
-        <S.ProgressBar percent={countPercentage} />
+        <S.ProgressBar percent={countPercentage} status="normal" />
       </S.LeftColumn>
       <S.RightColumn span={16}>
         <Title

--- a/front/src/components/lessonBlocks/OngoingShort/OngoingShort.mobile.jsx
+++ b/front/src/components/lessonBlocks/OngoingShort/OngoingShort.mobile.jsx
@@ -20,9 +20,12 @@ const OngoingShortMobile = ({ lesson }) => {
     history.push(LEARN_PAGE.replace(':id', id));
   };
 
-  const countPercentage = useMemo(() =>
-    Math.round((interactivePassed / interactiveTotal) * 100), 
-  [interactivePassed, interactiveTotal]);
+  const countPercentage = useMemo(() => {
+    if (!lesson.interactiveTotal && lesson.isStarted) {
+      return 100;
+    }
+    return Math.round((interactivePassed / interactiveTotal) * 100);
+  }, [lesson, interactivePassed, interactiveTotal]);
 
   return (
     <S.MainSpace>

--- a/front/src/components/lessonBlocks/OngoingShort/OngoingShort.mobile.jsx
+++ b/front/src/components/lessonBlocks/OngoingShort/OngoingShort.mobile.jsx
@@ -31,7 +31,7 @@ const OngoingShortMobile = ({ lesson }) => {
     <S.MainSpace>
       <S.LeftColumn span={8}>
         <S.StyledImage src={lessonImg} alt="Lesson" />
-        <S.ProgressBar percent={countPercentage} />
+        <S.ProgressBar percent={countPercentage} status="normal" />
       </S.LeftColumn>
       <S.RightColumn span={16}>
         <Title

--- a/front/src/pages/User/LearnPage/LearnPage.jsx
+++ b/front/src/pages/User/LearnPage/LearnPage.jsx
@@ -1,5 +1,4 @@
 /* eslint no-use-before-define: "off" */
-
 import { useParams } from 'react-router-dom';
 
 import Header from '@sb-ui/components/molecules/Header';
@@ -19,11 +18,15 @@ const LearnPage = () => {
     lesson,
     total,
     learnProgress,
+    progressStatus,
   } = useLearnChunks({ lessonId });
 
   return (
     <>
-      <Header hideOnScroll bottom={<S.Progress percent={learnProgress} />} />
+      <Header
+        hideOnScroll
+        bottom={<S.Progress percent={learnProgress} status={progressStatus} />}
+      />
       <S.Wrapper>
         <S.GlobalStylesLearnPage />
         <S.Row>

--- a/front/src/pages/User/LearnPage/useLearnChunks.js
+++ b/front/src/pages/User/LearnPage/useLearnChunks.js
@@ -93,6 +93,9 @@ export const useLearnChunks = ({ lessonId }) => {
   const [lesson, setLesson] = useState({});
   const [learnProgress, setLearnProgress] = useState(0);
   const [passedBlocks, setPassedBlocks] = useState(0);
+  const [progressStatus, setProgressStatus] = useState('normal');
+  const [isFinalChunk, setIsFinalChunk] = useState(false);
+  const [isFinishedLesson, setIsFinishedLesson] = useState(false);
 
   const { data: getData, isLoading } = useQuery(
     [
@@ -107,13 +110,33 @@ export const useLearnChunks = ({ lessonId }) => {
   const onSuccess = useCallback(
     (data) => {
       setChunks((prevChunks) => handleAnswer({ data, prevChunks }));
-      setPassedBlocks(passedBlocks + 1);
     },
-    [setChunks, passedBlocks],
+    [setChunks],
   );
+
+  const onMutate = useCallback(
+    (data) => {
+      if (data.action === 'start' && !lesson.interactiveTotal) {
+        setIsFinalChunk(true);
+      }
+      if (data.action === 'finish') {
+        setProgressStatus('success');
+      }
+      if (data.action !== 'start' && data.action !== 'finish') {
+        setPassedBlocks((prevPassed) => prevPassed + 1);
+      }
+    },
+    [lesson],
+  );
+
+  const onError = useCallback(() => {
+    setPassedBlocks((prevPassed) => prevPassed - 1);
+  }, []);
 
   const { mutate: handleInteractiveClick } = useMutation(postLessonById, {
     onSuccess,
+    onMutate,
+    onError,
   });
 
   useEffect(() => {
@@ -135,14 +158,21 @@ export const useLearnChunks = ({ lessonId }) => {
       setTotal(newTotal);
       setLesson(newLesson);
       setPassedBlocks(newLesson.interactivePassed);
+      setProgressStatus(isFinished ? 'success' : 'normal');
+      setIsFinalChunk(isFinal);
+      setIsFinishedLesson(isFinished);
     }
   }, [getData]);
 
   useEffect(() => {
-    setLearnProgress(
-      Math.round((passedBlocks / lesson.interactiveTotal) * 100),
-    );
-  }, [passedBlocks, lesson]);
+    if ((!lesson.interactiveTotal && isFinalChunk) || isFinishedLesson) {
+      setLearnProgress(100);
+    } else {
+      setLearnProgress(
+        Math.round((passedBlocks / lesson.interactiveTotal) * 100),
+      );
+    }
+  }, [isFinalChunk, isFinishedLesson, passedBlocks, lesson]);
 
   return {
     handleInteractiveClick,
@@ -151,5 +181,6 @@ export const useLearnChunks = ({ lessonId }) => {
     lesson,
     isLoading,
     learnProgress,
+    progressStatus,
   };
 };


### PR DESCRIPTION
* Fix incorrect learn progress bar behavior:
    - progress bar increases only on interactive action
    - if the lesson is not finished progress bar will be 100%, but not 'success'
![image](https://user-images.githubusercontent.com/83835856/127470415-359cae1e-6718-45c9-be76-fb3342f612cf.png)
    - if the lesson is finished progress bar will be 'success'
![image](https://user-images.githubusercontent.com/83835856/127470511-b569e6eb-9bed-4e8f-aa27-d1eb674f36f1.png)

* Fix incorrect total blocks count:
    - if a lesson has no blocks count == 0
![image](https://user-images.githubusercontent.com/83835856/127469927-e6452b2a-1026-495e-922a-32fb767a93a7.png)
    - if a lesson has only non-interactive blocks count == 1
![image](https://user-images.githubusercontent.com/83835856/127470096-9c05679c-852a-403d-adf2-7dc050473c23.png)
    - else count == number of interactive blocks