### PR TITLE
(SBL-391) Fix: bugs in Fill-the-gap block

### DIFF
--- a/front/src/pages/Teacher/LessonEdit/utils.js
+++ b/front/src/pages/Teacher/LessonEdit/utils.js
@@ -79,6 +79,7 @@ const SKIP_BLOCKS = [
   BLOCKS_TYPE.EMBED,
   BLOCKS_TYPE.IMAGE,
   BLOCKS_TYPE.CLOSED_QUESTION,
+  BLOCKS_TYPE.FILL_THE_GAP,
 ];
 
 export const prepareBlocksForApi = (blocks) =>
@@ -173,7 +174,10 @@ export const getConfig = (t) => ({
       inlineToolbar: true,
     },
     code: CodeTool,
-    fillTheGap: FillTheGap,
+    fillTheGap: {
+      class: FillTheGap,
+      inlineToolbar: true,
+    },
   },
   plugins: [],
 });

--- a/front/src/pages/User/LearnPage/BlockElement/FillTheGap/FillTheGap.jsx
+++ b/front/src/pages/User/LearnPage/BlockElement/FillTheGap/FillTheGap.jsx
@@ -29,7 +29,7 @@ const FillTheGap = ({
   const { t } = useTranslation('user');
   const { handleInteractiveClick, id } = useContext(LearnContext);
 
-  const { tokens } = content.data;
+  const { tokens } = content.data || {};
 
   const [gapsInput, setGapsInput] = useState(
     tokens?.map((token) => {
@@ -48,7 +48,7 @@ const FillTheGap = ({
       revision,
       blockId,
       reply: {
-        response: gapsInput.filter((gap) => gap.type === 'input'),
+        response: gapsInput?.filter((gap) => gap.type === 'input'),
       },
     });
   }, [blockId, gapsInput, handleInteractiveClick, id, revision]);

--- a/front/src/pages/User/LearnPage/BlockElement/FillTheGap/GapsInput/GapsInput.jsx
+++ b/front/src/pages/User/LearnPage/BlockElement/FillTheGap/GapsInput/GapsInput.jsx
@@ -2,6 +2,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { htmlToReact } from '@sb-ui/pages/User/LearnPage/utils';
+
 import * as S from './GapsInput.styled';
 
 const GapsInput = ({ gaps, setGaps, disabled, result }) => {
@@ -17,9 +19,9 @@ const GapsInput = ({ gaps, setGaps, disabled, result }) => {
 
   return (
     <S.Wrapper>
-      {gaps.map(({ value, id, type }) => {
+      {gaps?.map(({ value, id, type }) => {
         if (type === 'text') {
-          return <span key={id}>{value}</span>;
+          return <span key={id}>{htmlToReact(value)}</span>;
         }
         if (result) {
           const { value: resultValue, correct: correctValue } =

--- a/front/src/resources/lang/en/editorjs.js
+++ b/front/src/resources/lang/en/editorjs.js
@@ -76,6 +76,10 @@ export default {
       example: 'Example',
       none: 'none',
     },
+    fill_the_gap: {
+      hint: '* Text inside {{ }} will be hidden for students',
+      placeholder: 'Enter a text',
+    },
     warning: {
       title: 'Warning',
       placeholder: 'Title',

--- a/front/src/resources/lang/ru/editorjs.js
+++ b/front/src/resources/lang/ru/editorjs.js
@@ -76,6 +76,10 @@ export default {
       example: 'Пример',
       none: 'пусто',
     },
+    fill_the_gap: {
+      hint: '* Текст внутри {{ }} будет скрыт для студентов',
+      placeholder: 'Введите текст',
+    },
     warning: {
       title: 'Предупреждение',
       placeholder: 'Заголовок',

--- a/front/src/utils/editorjs/EditorJsContainer/EditorJsContainer.jsx
+++ b/front/src/utils/editorjs/EditorJsContainer/EditorJsContainer.jsx
@@ -189,6 +189,10 @@ const EditorJsContainer = forwardRef((props, ref) => {
               example: t('tools.closed_question.example'),
               none: t('tools.closed_question.none'),
             },
+            fillTheGap: {
+              hint: t('tools.fill_the_gap.hint'),
+              placeholder: t('tools.fill_the_gap.placeholder'),
+            },
             warning: {
               placeholder: t('tools.warning.placeholder'),
               message: t('tools.warning.message'),

--- a/front/src/utils/editorjs/utils.js
+++ b/front/src/utils/editorjs/utils.js
@@ -23,3 +23,9 @@ export const fileToBase64 = (file) =>
     reader.onload = () => resolve(reader.result);
     reader.onerror = (error) => reject(error);
   });
+
+export const stripHTML = (html) => {
+  const tmp = document.createElement('div');
+  tmp.innerHTML = html;
+  return tmp.textContent || tmp.innerText || '';
+};


### PR DESCRIPTION
Fix bugs:
- [X] 1. (Teacher View)  When remove all text from Fill the gap input and Save it, input fills with default text and content data null saved to server with empty answer object {}
- [X] 2. (Student View) When content data of blocks is null, page falling with error
- [X] 3. (Teacher View) When remove all mustaches from fill the gap input it causes the same bug as 1.
- [X] 4. (Teacher View) It should remove automatically the same words after Save block
- [X] 5. (Teacher View) It should have Inline toolbar
- [X] 6. (Student view) Should render raw html
- [X] 7. (Teacher view) Impossible to create multiple word phrases, Not all spaces between phrases are removed after Save
- [X] 8. (Teacher view) Empty mustaches are not removed after Save
- [X] 9. (Teacher view) No localization for hint 
- [X] 10. (Teacher view) Last comma saves empty string to answer 