### PR TITLE
(SBL-424) Fix: bugs in Fill-the-gap block after QA2

### DIFF
--- a/api/src/models/blocks/fillTheGap.js
+++ b/api/src/models/blocks/fillTheGap.js
@@ -1,16 +1,16 @@
 export function getFillTheGapCorrectness({
-  solution,
-  userResponse,
+  solution: { results },
+  userResponse: { response },
   blockWeight,
 }) {
-  const replies = userResponse.reduce(
+  const replies = response.reduce(
     (result, reply) => ({
       ...result,
       [reply.id]: reply,
     }),
     {},
   );
-  return solution.every(
+  return results.every(
     (answer) =>
       replies[answer.id] && answer.value.includes(replies[answer.id].value),
   )

--- a/front/src/pages/User/LearnPage/BlockElement/FillTheGap/GapsInput/GapsInput.jsx
+++ b/front/src/pages/User/LearnPage/BlockElement/FillTheGap/GapsInput/GapsInput.jsx
@@ -30,7 +30,7 @@ const GapsInput = ({ gaps, setGaps, disabled, result }) => {
           return (
             <React.Fragment key={id}>
               {correctValue ? (
-                <S.CorrectSpan>{resultValue?.[0]}</S.CorrectSpan>
+                <S.CorrectSpan>{resultValue}</S.CorrectSpan>
               ) : (
                 <S.WrongSpan>{resultValue?.[0]}</S.WrongSpan>
               )}

--- a/front/src/pages/User/LearnPage/InfoBlock/InfoBlock.jsx
+++ b/front/src/pages/User/LearnPage/InfoBlock/InfoBlock.jsx
@@ -21,14 +21,7 @@ const InfoBlock = ({ isLoading, lesson, total }) => {
         <Skeleton loading={isLoading} paragraph={{ rows: 2 }} active />
       ) : (
         <>
-          <S.TitleEllipsis
-            ellipsis={{
-              tooltip: true,
-            }}
-            level={2}
-          >
-            {lesson.name}
-          </S.TitleEllipsis>
+          <S.TitleEllipsis>{lesson.name}</S.TitleEllipsis>
           <S.StyledRow>{lesson.description}</S.StyledRow>
           <S.StyledRow justify="space-between">
             <Text type="secondary">

--- a/front/src/pages/User/LearnPage/InfoBlock/InfoBlock.styled.js
+++ b/front/src/pages/User/LearnPage/InfoBlock/InfoBlock.styled.js
@@ -14,6 +14,10 @@ export const StyledRow = styled(Row)`
   width: 100%;
 `;
 
-export const TitleEllipsis = styled(Title)`
-  overflow-wrap: anywhere;
-`;
+export const TitleEllipsis = styled(Title).attrs({
+  level: 2,
+  ellipsis: {
+    tooltip: true,
+    rows: 3,
+  },
+})``;


### PR DESCRIPTION
Fixed
- [X] Correctness function is not working
- [X] The partially right answer is not shown correctly (just a first letter of the right answer).
- [X] Long lesson name breaks mobile view on the learn page.