### PR TITLE
(SBL-425) Fix: bugs in Cover image link  after QA

### DIFF
--- a/front/src/components/lessonBlocks/Teacher/Teacher.styled.js
+++ b/front/src/components/lessonBlocks/Teacher/Teacher.styled.js
@@ -32,6 +32,7 @@ export const ImageCol = styled(Col)`
 `;
 
 export const BadgeWrapper = styled.div`
+  z-index: 1;
   right: 1rem;
   top: 1rem;
   position: absolute;

--- a/front/src/pages/Teacher/LessonEdit/LessonImage/LessonImage.jsx
+++ b/front/src/pages/Teacher/LessonEdit/LessonImage/LessonImage.jsx
@@ -7,6 +7,8 @@ import DefaultLessonImage from '@sb-ui/resources/img/lesson.svg';
 
 import * as S from './LessonImage.styled';
 
+const MAX_IMAGE_LENGTH = 255;
+
 const LessonImage = ({
   isLoading,
   image,
@@ -21,6 +23,7 @@ const LessonImage = ({
       <Col span={24}>{t('lesson_edit.cover_image.title')}</Col>
       <Col span={24}>
         <Input
+          maxLength={MAX_IMAGE_LENGTH}
           allowClear
           value={image}
           placeholder={t('lesson_edit.cover_image.input_placeholder')}


### PR DESCRIPTION
Fix bugs:
- [X] The lesson status tag got removed
- [X] On lesson edit page image will be shown if you paste a base64 