### PR TITLE
(SBL-493) Fix: margins in Editor.js blocks

### DIFF
--- a/front/src/utils/editorjs/EditorJsContainer/EditorJsContainer.jsx
+++ b/front/src/utils/editorjs/EditorJsContainer/EditorJsContainer.jsx
@@ -7,6 +7,8 @@ import Paragraph from '@editorjs/paragraph';
 
 import Undo from '@sb-ui/utils/editorjs/undo-plugin';
 
+import * as S from './EditorJsContainer.styled';
+
 const EditorJsContainer = forwardRef((props, ref) => {
   const mounted = useRef();
   const { t } = useTranslation('editorjs');
@@ -280,7 +282,12 @@ const EditorJsContainer = forwardRef((props, ref) => {
     return () => {};
   }, [changeData, props]);
 
-  return children || <div id={holder} />;
+  return (
+    <>
+      <S.GlobalStylesEditorPage toolbarHint={t('tools.hint')} />
+      {children || <div id={holder} />}
+    </>
+  );
 });
 
 EditorJsContainer.propTypes = {

--- a/front/src/utils/editorjs/EditorJsContainer/EditorJsContainer.styled.js
+++ b/front/src/utils/editorjs/EditorJsContainer/EditorJsContainer.styled.js
@@ -1,0 +1,9 @@
+import { createGlobalStyle } from 'styled-components';
+
+export const GlobalStylesEditorPage = createGlobalStyle`
+  .codex-editor__redactor{
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+`;

--- a/front/src/utils/editorjs/closed-question-plugin/closedQuestion.css
+++ b/front/src/utils/editorjs/closed-question-plugin/closedQuestion.css
@@ -1,5 +1,4 @@
 .closed-question-tool {
-  margin-top: 1rem;
 }
 
 .closed-question-tool__answer-input {

--- a/front/src/utils/editorjs/image-plugin/image.css
+++ b/front/src/utils/editorjs/image-plugin/image.css
@@ -9,7 +9,6 @@
 }
 
 .image-tool {
-  margin-top: 1rem;
 }
 
 .image-tool__caption {

--- a/front/src/utils/editorjs/match-plugin/match.css
+++ b/front/src/utils/editorjs/match-plugin/match.css
@@ -2,7 +2,6 @@
   display: flex;
   flex-direction: column;
   align-items: flex-end;
-  margin-top: 1rem;
 }
 
 .match-tool__input {

--- a/front/src/utils/editorjs/next-plugin/next.css
+++ b/front/src/utils/editorjs/next-plugin/next.css
@@ -1,7 +1,3 @@
-.next-tool__wrapper {
-  margin: 1rem 0;
-}
-
 .next-tool__base {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Add css flex gap instead of margins for editorjs blocks
![2021-09-24_13-08](https://user-images.githubusercontent.com/42850697/134657986-594a075c-abdf-4dcb-b3f1-7f543aa28150.png)
![2021-09-24_13-08_1](https://user-images.githubusercontent.com/42850697/134657993-57bbb015-0b9a-4272-b9cf-b1b26caa1436.png)

