### PR TITLE
(SBL-588) Fix: Make lesson learn flow work correctly

### DIFF
--- a/front/src/pages/User/LearnPage/useLearnChunks.js
+++ b/front/src/pages/User/LearnPage/useLearnChunks.js
@@ -53,6 +53,9 @@ export const createChunksFromBlocks = ({
   if (!isPost && isFinished && isEmptyBlocks) {
     chunks.push([createFinishBlock(true)]);
   }
+  if (!isPost && chunks?.[0]?.[0]?.type !== 'start') {
+    chunks.splice(0, 0, [createStartBlock(true)]);
+  }
 
   return chunks;
 };
@@ -78,6 +81,7 @@ export const handleAnswer = ({ data: serverData, prevChunks }) => {
   if (interactiveBlock) {
     interactiveBlock.isSolved = true;
   }
+
   return [
     ...prevChunks,
     ...createChunksFromBlocks({

--- a/front/src/pages/User/LearnPage/useLearnChunks.test.js
+++ b/front/src/pages/User/LearnPage/useLearnChunks.test.js
@@ -107,6 +107,7 @@ describe('Test useLearnChunks', () => {
         isPost: false,
       });
       expect(chunks).toStrictEqual([
+        [createStartBlock(true)],
         [createParagraphBlock(1, 'Paragraph1'), createFinishBlock(false)],
       ]);
     });
@@ -121,6 +122,8 @@ describe('Test useLearnChunks', () => {
         isPost: false,
       });
       expect(chunks).toStrictEqual([
+        [createStartBlock(true)],
+
         [
           createParagraphBlock(1, 'Paragraph1'),
           createQuizResultBlock(2, [true, true], [true, true]),
@@ -139,6 +142,8 @@ describe('Test useLearnChunks', () => {
         isPost: false,
       });
       expect(chunks).toStrictEqual([
+        [createStartBlock(true)],
+
         [createParagraphBlock(1, 'Paragraph1'), createNextBlock(2, false)],
       ]);
     });
@@ -153,6 +158,8 @@ describe('Test useLearnChunks', () => {
         isPost: false,
       });
       expect(chunks).toStrictEqual([
+        [createStartBlock(true)],
+
         [
           createParagraphBlock(1, 'Paragraph1'),
           createQuizResultBlock(2, [true, true], [true, true]),
@@ -167,7 +174,10 @@ describe('Test useLearnChunks', () => {
         isFinished: true,
         isPost: false,
       });
-      expect(chunks).toStrictEqual([[createFinishBlock(true)]]);
+      expect(chunks).toStrictEqual([
+        [createStartBlock(true)],
+        [createFinishBlock(true)],
+      ]);
     });
   });
 

--- a/front/src/utils/api/config.js
+++ b/front/src/utils/api/config.js
@@ -9,7 +9,6 @@ export const interactiveTypesBlocks = [
   BLOCKS_TYPE.FILL_THE_GAP,
   BLOCKS_TYPE.BRICKS,
   BLOCKS_TYPE.MATCH,
-  BLOCKS_TYPE.FINISH,
   BLOCKS_TYPE.GRADED_QUESTION,
 ];
 export const staticTypesBlocks = [


### PR DESCRIPTION
Start block should always be in chunks (resolved or not resolved). So added it manually where it needed