### PR TITLE
(SBL-611) Fix: Force focus to block after 'Esc' when tools menu is open

### DIFF
--- a/front/src/utils/editorjs/EditorJsContainer/EditorJsContainer.jsx
+++ b/front/src/utils/editorjs/EditorJsContainer/EditorJsContainer.jsx
@@ -12,7 +12,9 @@ import * as S from './EditorJsContainer.styled';
 const EditorJsContainer = forwardRef((props, ref) => {
   const mounted = useRef();
   const { t } = useTranslation('editorjs');
-  const { prepareToolbox, updateLanguage } = useToolbox();
+  const instance = useRef(null);
+
+  const { prepareToolbox, updateLanguage } = useToolbox({ editor: instance });
 
   const { children, language } = props;
   const holder = useMemo(
@@ -24,7 +26,6 @@ const EditorJsContainer = forwardRef((props, ref) => {
   );
 
   const initialLanguage = useRef(language);
-  const instance = useRef(null);
 
   const handleChange = useCallback(
     async (api) => {

--- a/front/src/utils/editorjs/EditorJsContainer/useToolbox/constants.js
+++ b/front/src/utils/editorjs/EditorJsContainer/useToolbox/constants.js
@@ -8,6 +8,7 @@ export const DEBOUNCE_SCROLL_TOOLBOX_TIME = 50; // ms;
 export const KEYS = {
   TAB: 'Tab',
   ENTER: 'Enter',
+  ESCAPE: 'Escape',
   ARROW_UP: 'ArrowUp',
   ARROW_DOWN: 'ArrowDown',
 };

--- a/front/src/utils/editorjs/EditorJsContainer/useToolbox/useToolbox.js
+++ b/front/src/utils/editorjs/EditorJsContainer/useToolbox/useToolbox.js
@@ -6,6 +6,7 @@ import { debounce } from '@sb-ui/utils/utils';
 
 import {
   DEBOUNCE_SCROLL_TOOLBOX_TIME,
+  KEYS,
   TOOLBOX_OPENED,
   TOOLBOX_UPPER,
 } from './constants';
@@ -26,7 +27,7 @@ import {
 } from './toolboxItemsHelpers';
 import { destroyObserver, initObserver } from './toolboxObserver';
 
-export const useToolbox = () => {
+export const useToolbox = ({ editor }) => {
   const { t } = useTranslation('editorjs');
   const toolbox = useRef(null);
   const [isReady, setIsReady] = useState(false);
@@ -69,6 +70,12 @@ export const useToolbox = () => {
   const prepareToolbox = useCallback(() => {
     toolbox.current = document.querySelector('.ce-toolbox');
     const wrapper = toolbox.current;
+    wrapper.addEventListener('keydown', (e) => {
+      if (e.code === KEYS.ESCAPE) {
+        const currentBlockIndex = editor.current.blocks.getCurrentBlockIndex();
+        editor.current.caret.setToBlock(currentBlockIndex);
+      }
+    });
     const basicCheck = wrapper?.querySelector('.toolbox-basic-items');
     if (!wrapper || basicCheck) {
       return;
@@ -118,6 +125,9 @@ export const useToolbox = () => {
     transformDefaultMenuItems(interactiveItems, interactiveMenuItemsWrapper, t);
     transformDefaultMenuItems(basicItems, basicMenuItemsWrapper, t);
     setIsReady(true);
+    // EditorJS instance ref is passing (creating with useRef())
+    // No need passing to useCallback dependencies
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [t]);
 
   useEffect(() => {


### PR DESCRIPTION
Force focus to block after 'Esc' when tools menu is open