### PR TITLE
(SBL-613) Fix: Force Toolbox not to jumping if screen height is small for it

### DIFF
--- a/front/src/utils/editorjs/EditorJsContainer/useToolbox/domToolboxHelpers.js
+++ b/front/src/utils/editorjs/EditorJsContainer/useToolbox/domToolboxHelpers.js
@@ -1,3 +1,4 @@
+import { HEADER_HEIGHT } from '@sb-ui/components/molecules/Header/Header.styled';
 import { TOOLBOX_UPPER } from '@sb-ui/utils/editorjs/EditorJsContainer/useToolbox/constants';
 
 import { getTranslationKey } from './toolboxItemsHelpers';
@@ -86,13 +87,11 @@ export const TOP_OVERLAPS = 'top';
 export const BOTTOM_OVERLAPS = 'bottom';
 
 export const getElementOverlapsPosition = (el) => {
-  const rect = el.getBoundingClientRect();
-  if (rect.top < 0) {
+  const { top, height, bottom } = el.getBoundingClientRect();
+  if (top < HEADER_HEIGHT || window.innerHeight < height * 2 + HEADER_HEIGHT) {
     return TOP_OVERLAPS;
   }
-  if (
-    rect.bottom > (window.innerHeight || document.documentElement.clientHeight)
-  ) {
+  if (bottom > (window.innerHeight || document.documentElement.clientHeight)) {
     return BOTTOM_OVERLAPS;
   }
 


### PR DESCRIPTION
![fix](https://user-images.githubusercontent.com/42850697/139011714-df03bf01-f817-40d0-b25c-79e57c1db483.gif)
